### PR TITLE
Update to bullseye to address vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # docker run --rm -it --net host bitnami/wait-for-port
 #
-FROM golang:1.18-stretch as build
+FROM golang:1.18-bullseye as build
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git make upx \
@@ -17,7 +17,7 @@ RUN make
 
 RUN upx --ultra-brute out/wait-for-port
 
-FROM bitnami/minideb:stretch
+FROM bitnami/minideb:bullseye
 
 COPY --from=build /go/src/app/out/wait-for-port /usr/local/bin/
 


### PR DESCRIPTION
The image `golang:1.18-stretch` is no longer receiving updates.  This means that builds of this project are not getting security updates for Go past 1.18.2.  

Switching this project to use `bullseye` for building and final image will address this.  

Fixes #10

Signed-off-by: Liam Newman <liam@verta.ai>