### PR TITLE
Use GoReleaser to build binaries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,14 +6,17 @@ on:
   push:
     branches:
       - main
-
-  release:
-    types: [published]
+    tags:
+      - v*
 
   pull_request:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -24,8 +27,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v4
         with:
           go-version: '^1.18.8' # The Go version to download (if necessary) and use.
       - name: Install Build Dependencies
@@ -39,59 +44,16 @@ jobs:
       - name: Cover
         run: make cover
       - name: Build
-        run: |
-          set -ex
-          for dist in amd64 arm64; do
-             target=out/wait-for-port-linux-$dist
-             rm -rf "$target"
-             make build/$dist TOOL_PATH="$target"
-             file $target
-             tar -C "$(dirname "$target")" -czf "$target.tar.gz" "$(basename "$target")"
-          done
-      - uses: actions/upload-artifact@v2
+        uses: goreleaser/goreleaser-action@v4
+        if: "!startsWith(github.ref, 'refs/tags/')"
         with:
-          name: built-binaries
-          path: |
-            out/*.tar.gz
-  release:
-    needs: [ 'build-and-test' ]
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
-        with:
-          path: ./artifacts
-      - name: Set tag name
-        id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+          version: latest
+          args: build --snapshot --clean
       - name: Release
-        run: |
-          set -e
-          create_digest_file() {
-              local digest_file=${1:?You must provide the digest file path}
-              shift
-              for file in "$@"; do
-                (
-                   cd "$(dirname "$file")"
-                   sha256sum "$(basename "$file")"
-                ) >> "$digest_file"
-              done
-          }
-          assets=( ./artifacts/built-binaries/*.gz )
-
-          tag_name="${{ steps.vars.outputs.tag }}"
-          checksums_file="${tag_name}_checksums.txt"
-          create_digest_file "$checksums_file" "${assets[@]}"
-          assets+=( "$checksums_file" )
-          if gh release view "$tag_name" >/dev/null 2>/dev/null; then
-            echo "Release $tag_name already exists. Updating"
-            gh release upload "$tag_name" "${assets[@]}"
-          else
-            echo "Creating new release $tag_name"
-            # Format checksums for the release text
-            printf '```\n%s\n```' "$(<"$checksums_file")" > release.txt
-            gh release create -t "$tag_name" "$tag_name" -F release.txt "${assets[@]}"
-          fi
+        uses: goreleaser/goreleaser-action@v4
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          version: latest
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 out/
+/dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,12 @@
+env:
+  - CGO_ENABLED=0
+builds:
+  - targets:
+      - linux_amd64
+      - linux_arm64
+archives:
+  - name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
+checksum:
+  name_template: '{{ .Version }}_checksums.txt'
+changelog:
+  use: github-native


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

This PR changes the build process to instead use [GoReleaser](https://goreleaser.com/) to build the release binaries.

### Benefits

<!-- What benefits will be realized by the code change? -->

I use [this action](https://github.com/jaxxstorm/action-install-gh-release) to automatically install tools from GitHub releases into my GitHub Actions workflows. It works mostly ok with your existing releases, downloading the latest release that matches the OS and architecture my workflow is running on, however because the binary within the release archive still has the OS and architecture as part of the filename, I have to make sure my workflow runs `wait-for-port-$(uname -s)-$(uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')` to ensure portability instead of just `wait-for-port`.

While I was trying to work out the cleanest way to change the binary filenames, I figured it would be just easier to use GoReleaser instead which is a popular tool for building Golang-based releases. This removes a lot of the boilerplate from your existing workflow. It also creates the releases for you with the changelog entries, etc. so you just need to push the new version tag.

Supporting more OS/architecture combinations is also easy to change by just updating the `.goreleaser.yml` configuration file.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

Anyone expecting the previous behaviour of the binary having the OS and architecture as part of the binary filename.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #9 (by accident)

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

I've tuned the GoReleaser configuration so it creates release tarballs and checksums with the same filenames as previous releases.

I've disabled Cgo which means static stripped binaries are built as standard. Contrary to the comments in #9 the size of the binaries is almost exactly the same as the dynamically-linked versions, about 2 MiB so this means things will work on Alpine.

I've also updated the some of the actions to their latest versions, I'd recommend maybe enabling Dependabot to keep these updated.