### PR TITLE
Upgrade GH actions and configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+version: 2
+# Check for updates to GitHub Actions every week
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,8 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-
+# Remove all permissions by default
+permissions: {}
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -24,8 +25,8 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed
         with:
           go-version: '^1.22.4' # The Go version to download (if necessary) and use.
       - name: Install Build Dependencies
@@ -48,7 +49,7 @@ jobs:
              file $target
              tar -C "$(dirname "$target")" -czf "$target.tar.gz" "$(basename "$target")"
           done
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
         with:
           name: built-binaries
           path: |
@@ -58,8 +59,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           path: ./artifacts
       - name: Set tag name


### PR DESCRIPTION
### Description of the change
* Update github workflows.
* Configure dependabot to keep actions up to date automatically.

### Benefits

Keep our code updated.

### Applicable issues
* https://github.com/bitnami/gonit/actions/runs/11568800660/job/32201354976?pr=56

### Possible drawbacks

Some actions were updated to a new major version.
