### PR TITLE
Update Go version to 1.24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
         with:
-          go-version: '^1.22.4' # The Go version to download (if necessary) and use.
+          go-version: '^1.24.4' # The Go version to download (if necessary) and use.
       - name: Install Build Dependencies
         run: make get-build-deps
       - name: Download required modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # docker run --rm -it --net host bitnami/wait-for-port
 #
-FROM golang:1.22-bullseye as build
+FROM golang:1.24-bookworm as build
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git make upx \
@@ -17,7 +17,7 @@ RUN make
 
 RUN upx --ultra-brute out/wait-for-port
 
-FROM bitnami/minideb:bullseye
+FROM bitnami/minideb:bookworm
 
 COPY --from=build /go/src/app/out/wait-for-port /usr/local/bin/
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bitnami/wait-for-port
 
-go 1.22
+go 1.24
 
 require (
 	github.com/jessevdk/go-flags v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/sys v0.21.0 // indirect
+	golang.org/x/sys v0.33.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.5 h1:s5PTfem8p8EbKQOctVV53k6jCJt3UX4IEJzwh+C324Q=
 github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
-golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
+golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
### Description of the change

Bump Go version to 1.24.

### Benefits

Keep the project updated.

### Possible drawbacks

Not expected

### Applicable issues


### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
